### PR TITLE
Add SQLite storage for Y-statements and chatbot endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This project visualizes MBSE decisions using git commits. A small Express server
 ## Project structure
 
 - `server.js` – Express backend serving commit information and diagrams.
+  Also stores commit messages (Y-statements) in a SQLite database and exposes
+  a chatbot API powered by OpenAI.
 - `public/` – Static frontend assets
   - `index.html`
   - `app.js`
@@ -20,13 +22,17 @@ This project visualizes MBSE decisions using git commits. A small Express server
    ```
 3. Set the path to your MBSE git repository via the `REPO_PATH` environment variable or modify `server.js`.
 4. Place `plantuml.jar` in the project root (or specify a different location via `PLANTUML_JAR`).
-5. Start the server:
+5. Set your OpenAI API key via the `OPENAI_API_KEY` environment variable if you
+   want to use the chatbot endpoint.
+6. Start the server:
    ```sh
    npm start
    ```
-6. Open `http://localhost:3001` in your browser to view the application.
+7. Open `http://localhost:3001` in your browser to view the application.
 
 ## Notes
 
 - Diagrams are generated on demand and stored under the `diagrams/` directory.
 - This repository does not include the actual MBSE project. Configure `REPO_PATH` to point to your own repository containing PlantUML files.
+- Y-statements extracted from commit messages are stored in `ystatements.db` and
+  can be queried via the `/ask` endpoint when an OpenAI API key is provided.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
   "dependencies": {
     "express": "^4.18.2",
     "cors": "^2.8.5",
-    "simple-git": "^3.16.0"
+    "simple-git": "^3.16.0",
+    "sqlite3": "^5.1.6",
+    "openai": "^4.14.0"
   }
 }


### PR DESCRIPTION
## Summary
- integrate SQLite and OpenAI clients in `server.js`
- store commit messages in `ystatements.db`
- expose `/ask` endpoint for chatbot queries
- document new features and update dependencies

## Testing
- `node -e "require('./server.js');"` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68541da15d0083218e17a1c61c08ba01