### PR TITLE
Clean previous repo and add change button

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -11,6 +11,7 @@ const metadataContent = document.getElementById("metadata-content");
 const graphContainer = document.getElementById("graph-container");
 const nextButton = document.getElementById("next-commit");
 const prevButton = document.getElementById("prev-commit");
+const changeRepoButton = document.getElementById("change-repo");
 
 // Temporary in-memory storage for commits
 let commitsDatabase = [];
@@ -186,12 +187,15 @@ function checkStoredRepo() {
     setRepository(stored).then(() => {
       repoForm.style.display = "none";
       diagramContainer.style.display = "inline-flex";
+      changeRepoButton.style.display = "inline";
       initializeApp();
     }).catch(() => {
       repoForm.style.display = "block";
+      changeRepoButton.style.display = "none";
     });
   } else {
     repoForm.style.display = "block";
+    changeRepoButton.style.display = "none";
   }
 }
 
@@ -203,6 +207,7 @@ repoSubmit.addEventListener("click", async () => {
     localStorage.setItem("repoPath", value);
     repoForm.style.display = "none";
     diagramContainer.style.display = "inline-flex";
+    changeRepoButton.style.display = "inline";
     initializeApp();
   } catch (e) {
     alert("Failed to load repository: " + e.message);
@@ -216,4 +221,10 @@ checkStoredRepo();
 // Add event listeners for navigation buttons
 nextButton.addEventListener("click", nextCommit);
 prevButton.addEventListener("click", prevCommit);
+changeRepoButton.addEventListener("click", () => {
+  localStorage.removeItem("repoPath");
+  repoForm.style.display = "block";
+  diagramContainer.style.display = "none";
+  changeRepoButton.style.display = "none";
+});
 

--- a/public/index.html
+++ b/public/index.html
@@ -13,6 +13,7 @@
   <!-- Header -->
   <header>
     <h2>DeciMaL - Decision Management Lab</h2>
+    <button id="change-repo" style="display:none;">Change Repository</button>
   </header>
   <div id="repo-form">
     <input id="repo-input" type="text" placeholder="Repository path or URL" />

--- a/public/styles.css
+++ b/public/styles.css
@@ -118,3 +118,8 @@ a:hover {
   justify-content: center;
 }
 
+/* Change repo button */
+#change-repo {
+  margin-left: 20px;
+}
+

--- a/server.js
+++ b/server.js
@@ -42,8 +42,18 @@ app.get('/', (req, res) => {
 let repoPath = process.env.REPO_PATH || path.join(__dirname, 'MBSE-Repo');
 // Directory where generated diagrams are stored
 const diagramsDir = path.join(__dirname, 'diagrams');
+// Directory where remote repositories are cloned
+const cloneDir = path.join(__dirname, 'cloned-repo');
 // PlantUML JAR location
 const plantUmlJar = process.env.PLANTUML_JAR || path.join(__dirname, 'plantuml.jar');
+
+// Clean previously cloned repository and generated diagrams on startup
+if (fs.existsSync(cloneDir)) {
+    fs.rmSync(cloneDir, { recursive: true, force: true });
+}
+if (fs.existsSync(diagramsDir)) {
+    fs.rmSync(diagramsDir, { recursive: true, force: true });
+}
 
 // Enable CORS for frontend access
 app.use(cors({
@@ -63,7 +73,6 @@ app.post("/repo", async (req, res) => {
     repoPath = repo;
     return res.json({ repoPath });
   }
-  const cloneDir = path.join(__dirname, "cloned-repo");
   try {
     if (fs.existsSync(cloneDir)) {
       fs.rmSync(cloneDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- cleanup cloned repos and diagrams on startup
- provide change repo button for front-end
- show/hide repo change button in the UI

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68552cf4fa6083218f9e23afb9f04eee