### PR TITLE
Load OpenAI key from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ This project visualizes MBSE decisions using git commits. A small Express server
    ```
 3. Set the path to your MBSE git repository via the `REPO_PATH` environment variable or modify `server.js`.
 4. The PlantUML JAR (`plantuml.jar`) is already included in the project root. Set `PLANTUML_JAR` to use a different JAR.
-5. Set your OpenAI API key via the `OPENAI_API_KEY` environment variable if you
-   want to use the chatbot endpoint.
+5. Provide your OpenAI API key in a file named `key.txt` at the project root or
+   set the `OPENAI_API_KEY` environment variable. The server will automatically
+   read the key from `key.txt` if present.
 6. Start the server:
    ```sh
    npm start

--- a/server.js
+++ b/server.js
@@ -7,6 +7,19 @@ const cors = require('cors');
 const sqlite3 = require('sqlite3').verbose();
 const { OpenAI } = require('openai');
 
+// Load OpenAI API key from key.txt if present
+const keyFile = path.join(__dirname, 'key.txt');
+if (fs.existsSync(keyFile)) {
+    try {
+        const key = fs.readFileSync(keyFile, 'utf8').trim();
+        if (key) {
+            process.env.OPENAI_API_KEY = key;
+        }
+    } catch (err) {
+        console.error('Failed to read key.txt:', err.message);
+    }
+}
+
 const app = express();
 const port = process.env.PORT || 3001;
 


### PR DESCRIPTION
## Summary
- automatically load `OPENAI_API_KEY` from `key.txt`
- document that the API key can be stored in `key.txt`

## Testing
- `node server.js` *(fails: cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68553a1dd7948321bf096bcb2e7f5117