### PR TITLE
Fix commit order and fetch latest commits

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -55,8 +55,8 @@ async function initializeApp() {
     }
     commitsDatabase = await response.json();
 
-    // Reverse the commit order so that the initial commit (with no parents) is first
-    commitsDatabase.reverse();
+    // Commits are returned from newest to oldest; keep this order so the latest
+    // commit is shown first
 
     if (!Array.isArray(commitsDatabase) || commitsDatabase.length === 0) {
       throw new Error("No valid commit data received.");

--- a/server.js
+++ b/server.js
@@ -114,6 +114,11 @@ app.post("/repo", async (req, res) => {
   }
   if (fs.existsSync(repo)) {
     repoPath = repo;
+    try {
+      await simpleGit(repoPath).fetch();
+    } catch (err) {
+      console.error('Failed to fetch repository:', err.message);
+    }
     initializeDatabase();
     return res.json({ repoPath });
   }
@@ -123,6 +128,11 @@ app.post("/repo", async (req, res) => {
     }
     await simpleGit().clone(repo, cloneDir);
     repoPath = cloneDir;
+    try {
+      await simpleGit(repoPath).fetch();
+    } catch (err) {
+      console.error('Failed to fetch repository:', err.message);
+    }
     initializeDatabase();
     res.json({ repoPath });
   } catch (e) {
@@ -138,6 +148,12 @@ if (!fs.existsSync(diagramsDir)) {
 app.get('/commits', async (req, res) => {
     try {
         const git = simpleGit(repoPath);
+        // Ensure we have the latest commits from the repository
+        try {
+            await git.fetch();
+        } catch (err) {
+            console.error('Failed to fetch repository:', err.message);
+        }
         const logData = await git.raw([
             "log", "--all", "--graph", "--pretty=format:%h|%p|%s"
         ]);


### PR DESCRIPTION
## Summary
- keep commit list in latest-first order on the client
- refresh repository data when setting a repository path
- fetch new commits whenever `/commits` is called

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68553c38f3288321926bc7100fda7dac