### PR TITLE
Add side-chat search for Y-statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,6 @@ This project visualizes MBSE decisions using git commits. A small Express server
 - Diagrams are generated on demand and stored under the `diagrams/` directory.
 - This repository does not include the actual MBSE project. Configure `REPO_PATH` to point to your own repository containing PlantUML files.
 - Y-statements extracted from commit messages are stored in `ystatements.db` and
-  can be queried via the `/ask` endpoint when an OpenAI API key is provided.
+  can be queried via the `/ask` endpoint. The frontend includes a side chat tab
+  that sends questions to this endpoint and links the answer to the relevant
+  commit.

--- a/public/index.html
+++ b/public/index.html
@@ -38,6 +38,20 @@
     </div>
   </div>
 
+  <!-- Chatbot side panel -->
+  <button id="open-chat-btn">Chat</button>
+  <div id="chatbot-panel" class="chat-closed">
+    <div id="chatbot-header">
+      <span>Decision Chatbot</span>
+      <button id="close-chat-btn">X</button>
+    </div>
+    <div id="chat-messages"></div>
+    <div id="chat-input-container">
+      <input id="chat-input" type="text" placeholder="Ask about decisions..." />
+      <button id="chat-send-btn">Send</button>
+    </div>
+  </div>
+
   <!-- Load our custom JS code -->
   <script src="app.js"></script>
 </body>

--- a/public/styles.css
+++ b/public/styles.css
@@ -123,3 +123,58 @@ a:hover {
   margin-left: 20px;
 }
 
+/* Chatbot panel */
+#chatbot-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 300px;
+  height: 100%;
+  background: #f0f0f0;
+  box-shadow: -2px 0 5px rgba(0, 0, 0, 0.3);
+  display: flex;
+  flex-direction: column;
+  transform: translateX(100%);
+  transition: transform 0.3s ease;
+  z-index: 1000;
+}
+
+#chatbot-panel.open {
+  transform: translateX(0);
+}
+
+#chatbot-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px;
+  background: #0f122e;
+  color: white;
+}
+
+#chat-messages {
+  flex-grow: 1;
+  overflow-y: auto;
+  padding: 10px;
+}
+#chat-messages div {
+  margin-bottom: 8px;
+}
+
+#chat-input-container {
+  display: flex;
+  padding: 10px;
+}
+
+#chat-input {
+  flex-grow: 1;
+  margin-right: 5px;
+}
+
+#open-chat-btn {
+  position: fixed;
+  right: 10px;
+  bottom: 10px;
+  z-index: 999;
+}
+


### PR DESCRIPTION
## Summary
- add simple keyword search for y-statements on `/ask`
- add collapsible chat tab in frontend
- wire chat UI to query backend and navigate to commits
- style the chat side panel
- document the new chat tab in README

## Testing
- `node --check server.js`
- `node --check public/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68553e48a994832197806c5d96bf6061