### PR TITLE
Improve chatbot answer formatting

### DIFF
--- a/server.js
+++ b/server.js
@@ -390,7 +390,7 @@ app.post('/ask', (req, res) => {
             const messages = [
                 {
                     role: 'system',
-                    content: 'You answer questions about MBSE decisions. Use the provided commit messages to form a concise answer and mention commit hashes when relevant.'
+                    content: 'You answer questions about MBSE decisions. Use the provided commit messages to form a short summary. Mention relevant commits using the phrase "commit <hash>" and do not repeat the full commit messages.'
                 },
                 {
                     role: 'user',


### PR DESCRIPTION
## Summary
- ensure OpenAI prompt requests short summary with commit references
- show only the chatbot answer in the UI
- make commit hashes inside the answer clickable and open the related commit

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68554989ad3c8321b41c168d3d8c27d0