### PR TITLE
Use regex search instead of ChatGPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ This project visualizes MBSE decisions using git commits. A small Express server
 ## Project structure
 
 - `server.js` – Express backend serving commit information and diagrams.
-  Also stores commit messages (Y-statements) in a SQLite database and exposes
-  a chatbot API powered by OpenAI.
+  Stores commit messages (Y-statements) in a SQLite database and exposes a
+  query API that supports regular expression matching. Optional OpenAI
+  embeddings are used when available.
 - `public/` – Static frontend assets
   - `index.html`
   - `app.js`
@@ -36,8 +37,7 @@ This project visualizes MBSE decisions using git commits. A small Express server
 - Diagrams are generated on demand and stored under the `diagrams/` directory.
 - This repository does not include the actual MBSE project. Configure `REPO_PATH` to point to your own repository containing PlantUML files.
 - Y-statements extracted from commit messages are stored in `ystatements.db` with
-  OpenAI embeddings. The `/ask` endpoint performs a vector search over these
-  embeddings to understand the meaning of a question and return the most relevant
-  commits. The server then uses ChatGPT to form a short answer. The frontend
-  includes a side chat tab that displays the AI answer and links to the relevant
-  commit.
+  optional OpenAI embeddings. The `/ask` endpoint can search commit messages
+  using regular expressions and, when embeddings are available, performs a
+  vector search for additional context. Results are returned directly to the
+  frontend, which links to the relevant commit messages.


### PR DESCRIPTION
## Summary
- support regular expression queries in the `/ask` endpoint
- remove ChatGPT completion calls
- document regex-based query API

## Testing
- `node --check server.js`

------
https://chatgpt.com/codex/tasks/task_e_685575e0b118832199d9c3a3cb91ee75